### PR TITLE
Add dev script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./crmapp.js": "./dist/src/crmapp.js"
   },
   "scripts": {
+    "dev": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
     "start": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
     "build": "rimraf dist && tsc && node --max-old-space-size=4096 node_modules/rollup/dist/bin/rollup -c rollup.config.mjs",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open",


### PR DESCRIPTION
Added a new "dev" script to package.json that mirrors the existing "start" script functionality. This provides developers with a more conventional npm command for local development.

The new script runs TypeScript compilation and starts the development server using concurrent processes, matching the behavior of "start".

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=zen-home&projectId=9bb6c15a6d7c4f59a945efd1d6e815a9)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9bb6c15a6d7c4f59a945efd1d6e815a9</projectId>-->